### PR TITLE
ExpectUserDeprecation: Extension and Polyfill POC for PHPUnit 10 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 vendor/
 phpunit.xml
 .phpunit.result.cache
+.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    backupGlobals="true"
+    bootstrap="vendor/autoload.php"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    colors="true"
+    cacheDirectory=".cache/phpcs.cache"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    failOnWarning="true"
+    >
+  <testsuites>
+    <testsuite name="Bug Report Scenarios">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <extensions>
+    <bootstrap class="Jrf\PHPUnit\Scenario\Deprecation\DeprecationExtension"/>
+  </extensions>
+
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
+</phpunit>

--- a/src/Deprecation/DeprecationExtension.php
+++ b/src/Deprecation/DeprecationExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Jrf\PHPUnit\Scenario\Deprecation;
+
+use PHPUnit\Runner\Extension\Extension as PHPUnitExtension;
+use PHPUnit\TextUI\Configuration\Configuration;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\Event\Test\DeprecationTriggered;
+
+class DeprecationExtension implements PHPUnitExtension
+{
+    private static $instance;
+    protected array $actualDeprecations = [];
+    private $testInstance;
+
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscribers(
+            new DeprecationSubscriber(),
+            new VerifyDeprecationExpectationsSubscriber(),
+            new ResetSubscriber()
+         );
+    }
+
+    public static function instance(): self
+    {
+        if ( ! self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    public static function deprecations()
+    {
+        return self::instance()->actualDeprecations;
+    }
+
+    public static function deprecation($message)
+    {
+        return self::instance()->triggered($message)
+            ? self::instance()->actualDeprecations[$message]
+            : null;
+    }
+
+    public static function triggered($message): bool
+    {
+        return isset(self::instance()->actualDeprecations[$message]);
+    }
+
+    public function trigger(DeprecationTriggered $event): void
+    {
+        $message = $event->message();
+        $this->actualDeprecations[$message] = true;
+    }
+
+    public function setTestInstance($testInstance): void
+    {
+        $this->testInstance = $testInstance;
+    }
+
+    public function validate(): void
+    {
+        $this->testInstance->verifyDeprecationExpectations();
+    }
+
+    public function reset(): void
+    {
+        $this->actualDeprecations = [];
+        if ($this->testInstance)
+        {
+            $this->testInstance->resetExpectedUserDeprecationMessages();
+        }
+    }
+}

--- a/src/Deprecation/DeprecationSubscriber.php
+++ b/src/Deprecation/DeprecationSubscriber.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jrf\PHPUnit\Scenario\Deprecation;
+
+use PHPUnit\Event\Test\DeprecationTriggeredSubscriber;
+use PHPUnit\Event\Test\DeprecationTriggered;
+
+class DeprecationSubscriber implements DeprecationTriggeredSubscriber
+{
+    public function notify(DeprecationTriggered $event): void
+    {
+        DeprecationExtension::instance()->trigger($event);
+    }
+}

--- a/src/Deprecation/ResetSubscriber.php
+++ b/src/Deprecation/ResetSubscriber.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jrf\PHPUnit\Scenario\Deprecation;
+
+use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PreparedSubscriber;
+
+class ResetSubscriber implements PreparedSubscriber
+{
+    public function notify(Prepared $event): void
+    {
+        DeprecationExtension::instance()->reset();
+    }
+}

--- a/src/Deprecation/VerifyDeprecationExpectationsSubscriber.php
+++ b/src/Deprecation/VerifyDeprecationExpectationsSubscriber.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jrf\PHPUnit\Scenario\Deprecation;
+
+use PHPUnit\Event\Test\AfterTestMethodFinishedSubscriber;
+use PHPUnit\Event\Test\AfterTestMethodFinished;
+
+class VerifyDeprecationExpectationsSubscriber implements AfterTestMethodFinishedSubscriber
+{
+    public function notify(AfterTestMethodFinished $event): void
+    {
+        DeprecationExtension::instance()->validate($event);
+    }
+}

--- a/src/Deprecation/expectUserDeprecation.php
+++ b/src/Deprecation/expectUserDeprecation.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jrf\PHPUnit\Scenario\Deprecation;
+
+use PHPUnit\Event\Code\ComparisonFailureBuilder;
+use PHPUnit\Event\Code\ThrowableBuilder;
+use PHPUnit\Event\Facade as EventFacade;
+use PHPUnit\Framework\ExpectationFailedException;
+
+trait ExpectUserDeprecation
+{
+    protected $expectedUserDeprecationMessage = [];
+    protected $expectedUserDeprecationMessageRegularExpression = [];
+
+    final protected function expectUserDeprecationMessage($expectedUserDeprecationMessage): void
+    {
+        $this->setUpExpectUserDeprecation();
+        $this->expectedUserDeprecationMessage[$expectedUserDeprecationMessage] = false;
+    }
+
+    final protected function expectUserDeprecationMessageMatches($expectedUserDeprecationMessageRegularExpression): void
+    {
+        $this->setUpExpectUserDeprecation();
+        $this->expectedUserDeprecationMessageRegularExpression[] = $expectedUserDeprecationMessageRegularExpression;
+    }
+
+    private function setUpExpectUserDeprecation(): void
+    {
+        DeprecationExtension::instance()->setTestInstance($this);
+        $this->addToAssertionCount(1);
+    }
+
+    final public function verifyDeprecationExpectations(): void
+    {
+        foreach (array_keys($this->expectedUserDeprecationMessage) as $deprecationExpectation)
+        {
+            if (DeprecationExtension::triggered($deprecationExpectation))
+            {
+                static::assertThat(true, static::isTrue());
+            }
+            else
+            {
+                $message = sprintf(
+                        'Expected deprecation with message "%s" was not triggered',
+                        $deprecationExpectation,
+                );
+                $e = new ExpectationFailedException($message);
+                EventFacade::emitter()->testFailed(
+                    $this->valueObjectForEvents(),
+                    ThrowableBuilder::from($e),
+                    ComparisonFailureBuilder::from($e),
+                );    
+            }
+        }
+    }
+
+    public function resetExpectedUserDeprecationMessages(): void
+    {
+        $this->expectedUserDeprecationMessage = [];
+        $this->expectedUserDeprecationMessageRegularExpression = [];
+    }
+}

--- a/src/Foo.php
+++ b/src/Foo.php
@@ -3,8 +3,13 @@
 namespace Jrf\PHPUnit\Scenario;
 
 class Foo {
-	function throwDeprecation() {
-		trigger_error('deprecation', E_USER_DEPRECATED);
+	private $depCount = 0;
+	function throwDeprecation($message = '') {
+		if ('' === $message)
+		{
+			$message = 'Passing an empty string message is deprecated in ' . __METHOD__;
+		}
+		trigger_error($message, E_USER_DEPRECATED);
 		return true;
 	}
 

--- a/tests/FooTest.php
+++ b/tests/FooTest.php
@@ -2,12 +2,16 @@
 
 namespace Jrf\PHPUnit\Scenario\Tests;
 
+use Jrf\PHPUnit\Scenario\Deprecation\ExpectUserDeprecation;
 use Jrf\PHPUnit\Scenario\Foo;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FooTest extends TestCase {
+	use ExpectUserDeprecation;
 
 	private $classUnderTest;
+	private $firstDone = false;
 
 	/**
 	 * Initializes the test mock.
@@ -17,22 +21,64 @@ class FooTest extends TestCase {
 		parent::setUp();
 		$this->classUnderTest = new Foo();
 	}
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+	}
 
-    public function testDeprecation()
+	#[DataProvider('dataDeprecation')]
+	public function testHappyPath($message)
     {
-		$this->assertTrue($this->classUnderTest->throwDeprecation());
-		$this->assertTrue($this->classUnderTest->throwDeprecation());
-		$this->assertTrue($this->classUnderTest->throwDeprecation());
-    }
+		$this->expectUserDeprecationMessage($message);
+		$this->classUnderTest->throwDeprecation( $message );
+	}
 
-    public function testNotice()
+	#[DataProvider('dataDeprecation')]
+	public function testHappyPathWithMultipleAssertions($message)
     {
-		$this->assertTrue($this->classUnderTest->throwNotice());
-		$this->assertFalse($this->classUnderTest->throwNotice());
-    }
+		$this->expectUserDeprecationMessage($message);
+		$this->assertTrue($this->classUnderTest->throwDeprecation( $message ));
+		$this->assertFalse(false);
+	}
 
-    public function testWarning()
+	#[DataProvider('dataDeprecation')]
+	public function testUnhappyPath($message)
+	{
+		$this->expectUserDeprecationMessage('Test Unhappy Path');
+		$this->classUnderTest->throwDeprecation($message);
+	}
+
+	#[DataProvider('dataDeprecation')]
+	public function testUnhappyPathWithMultipleAssertions($message)
     {
-		$this->assertTrue($this->classUnderTest->throwWarning());
-    }
+		$this->expectUserDeprecationMessage('Test Unhappy Path');
+		$this->assertTrue($this->classUnderTest->throwDeprecation( $message ));
+		$this->assertFalse(false);
+	}
+
+	public static function dataDeprecation(): array
+	{
+		return [
+			'1st' => array('First deprecation'),
+			'2nd' => array('Second deprecation'),
+			'3rd' => array('Third deprecation'),
+		];
+	}
+
+	public function testAfterUnhappyPathWithMultipleAssertions()
+	{
+		$this->assertTrue(true);
+		$this->assertTrue(true);
+	}
+
+    // public function testNotice()
+    // {
+	// 	$this->assertTrue($this->classUnderTest->throwNotice());
+	// 	$this->assertFalse($this->classUnderTest->throwNotice());
+    // }
+
+    // public function testWarning()
+    // {
+	// 	$this->assertTrue($this->classUnderTest->throwWarning());
+    // }
 }


### PR DESCRIPTION
*** DO NOT MERGE ***

This is a Proof of Concept (POC).

[PHPUnit 10 extension](https://docs.phpunit.de/en/10.5/extending-phpunit.html#implementing-an-extension) for polyfilling `expectUserDeprecationMessage` and `expectUserDeprecationMessageMatches` that uses events.

The events used:
* `PHPUnit\Event\Test\Prepared` to reset collector properties between tests.
* `PHPUnit\Event\Test\DeprecationTriggered` to capture each deprecation triggered.
* `PHPUnit\Event\Test\AfterTestMethodFinished` to verify the expected deprecations.

This POC is not drop-in as it does require configuring the extension in the using / consuming project's `phpunit.xml`, e.g. 
```
  <extensions>
    <bootstrap class="Jrf\PHPUnit\Scenario\Deprecation\DeprecationExtension"/>
  </extensions>
```